### PR TITLE
[Feat] 마이페이지 메인 퍼블리싱 - 1 (발표 가능한 부분까지만 구현) 

### DIFF
--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -1,10 +1,179 @@
-const MyPageMain = () => {
+import style from "../styles/myPage.module.css";
+import Link from "next/link";
+
+/**
+ 작성자 : 정승민
+ 작성일 : 2024.06.12
+ TODO : 마이페이지 레이아웃 분리 예정
+*/
+
+const MyPageMain: React.FC = () => {
   return (
-    <div>
-      <h1>my page</h1>
+    <div className={style.myPageContainer}>
+      <div className={style.myPageMenu}>
+        <div className={style.profileContainer}>
+          <div className={style.dummyProfileImage} />
+          <p>김여행</p>
+        </div>
+        {/* 작성자 : 정승민
+        작성일 : 2024. 06. 08
+        설명 : 각 메뉴에 대해서 별도의 컴포넌트로 분리하여 리스트 렌더링 고민중 */}
+        <div className={style.menuList}>
+          <div className={style.eachMenu}>
+            <p className={style.eachMenuTitle}>나의 여정 &gt;</p>
+            <div className={style.horizontalLineWhite} />
+            <ul className={style.eachMenuList}>
+              <Link href={"/mypage/recentTrip"}>
+                <li>최근 여정 관리</li>
+              </Link>
+              <Link href={"/mypage/reservation"}>
+                <li>나의 예약 관리</li>
+              </Link>
+              <Link href={"/mypage/allTrip"}>
+                <li>나의 전체 여정 관리</li>
+              </Link>
+              <Link href={"/mypage/reviews"}>
+                <li>나의 리뷰 관리</li>
+              </Link>
+            </ul>
+          </div>
+
+          <div className={style.eachMenu}>
+            <p className={style.eachMenuTitle}>나의 친구 &gt;</p>
+            <div className={style.horizontalLineWhite} />
+            <ul className={style.eachMenuList}>
+              <Link href={"/mypage/myFriends"}>
+                <li>친구 목록 / 관리</li>
+              </Link>
+            </ul>
+          </div>
+
+          <div className={style.eachMenu}>
+            <p className={style.eachMenuTitle}>나의 프로필 &gt;</p>
+            <div className={style.horizontalLineWhite} />
+            <ul className={style.eachMenuList}>
+              <Link href={"/mypage/setting/profile"}>
+                <li>프로필 관리</li>
+              </Link>
+            </ul>
+          </div>
+
+          <div className={style.eachMenu}>
+            <p className={style.eachMenuTitle}>개인정보 설정 &gt;</p>
+            <div className={style.horizontalLineWhite} />
+            <ul className={style.eachMenuList}>
+              <Link href={"/mypage/setting/account"}>
+                <li>계정 설정</li>
+              </Link>
+              <Link href={"/mypage/setting/notifications"}>
+                <li>알림 설정</li>
+              </Link>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div className={style.myPageContents}>
+        <div className={style.myPageContentsTitle}>
+          <p>최근 여정 관리</p>
+          <div className={style.horizontalLineBlack} />
+        </div>
+
+        <div className={style.recentTripBanner}></div>
+
+        <div className={style.myPageContentsTitle}>
+          <p>여정의 예약 정보</p>
+          <div className={style.horizontalLineBlack} />
+        </div>
+
+        <div className={style.reservationInfoContainer}>
+          {/*항공권 예약 정보 */}
+          <div className={style.reservation}>
+            <div className={style.reservationSubject}>
+              <p>항공권</p>
+              <p>
+                <span>전체보기</span>
+              </p>
+            </div>
+            <div className={style.infoListContainer}>
+              <div className={style.eachReservationInfo}>
+                <div className={style.airlineLeft}>
+                  <p className={style.airlineName}>에어서울</p>
+                  <p className={style.airlineId}>OZ123</p>
+                </div>
+
+                <div className={style.airlineRight}>
+                  <p className={style.airlineName}>2024.06.12 - 07:30</p>
+                  <p className={style.airlineId}>인천국제공항(ICN) 1터미널</p>
+                </div>
+              </div>
+              <div className={style.eachReservationInfo}>
+                <div className={style.airlineLeft}>
+                  <p className={style.airlineName}>에어서울</p>
+                  <p className={style.airlineId}>OZ321</p>
+                </div>
+
+                <div className={style.airlineRight}>
+                  <p className={style.airlineName}>2024.06.13 - 13:30</p>
+                  <p className={style.airlineId}>나리타국제공항(NRT)</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/*숙박 예약 정보 */}
+          <div className={style.reservation}>
+            <div className={style.reservationSubject}>
+              <p>숙박</p>
+              <p>
+                <span>전체보기</span>
+              </p>
+            </div>
+
+            <div className={style.infoListContainer}>
+              <div className={style.eachReservationInfo}>
+                <div className={style.airlineLeft}>
+                  <p className={style.airlineName}>도쿄도 신주쿠구</p>
+                  <p className={style.airlineId}>토요코인 호텔 신주쿠</p>
+                </div>
+
+                <div className={style.airlineRight}>
+                  <p className={style.airlineName}>
+                    2024. 06. 12 ~ 2024. 06. 13
+                  </p>
+                  <p className={style.airlineId}>금연실 / 2인</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/*입장권 예약 정보 */}
+          <div className={style.reservation}>
+            <div className={style.reservationSubject}>
+              <p>입장권</p>
+              <p>
+                <span>전체보기</span>
+              </p>
+            </div>
+
+            <div className={style.infoListContainer}>
+              <div className={style.eachReservationInfo}>
+                <div className={style.airlineLeft}>
+                  <p className={style.airlineName}>도쿄타워</p>
+                  <p className={style.airlineId}>도쿄타워 입장권</p>
+                </div>
+
+                <div className={style.airlineRight}>
+                  <p className={style.airlineName}>2024. 06. 12</p>
+                  <p className={style.airlineId}>2인</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   );
 };
 
 export default MyPageMain;
-

--- a/app/styles/myPage.module.css
+++ b/app/styles/myPage.module.css
@@ -1,0 +1,217 @@
+.myPageContainer {
+  display: flex;
+  align-items: center;
+  gap: 60px;
+
+  width: 90%;
+}
+
+.myPageMenu {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+
+  padding: 40px 15px;
+  border-radius: 10px;
+  width: calc(20% - 30px);
+  height: 900px;
+
+  background-color: #b9b7b7;
+
+  .profileContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+
+    .dummyProfileImage {
+      width: 150px;
+      height: 150px;
+      border-radius: 50%;
+      background-color: #fff;
+    }
+
+    & > p {
+      font-size: 2em;
+      font-weight: 700;
+      color: #fff;
+    }
+  }
+
+  .menuList {
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+    width: 100%;
+
+    .eachMenu {
+      display: flex;
+      flex-direction: column;
+      align-items: start;
+      gap: 5px;
+
+      width: 100%;
+
+      .eachMenuTitle {
+        display: flex;
+        align-items: flex-start;
+        font-size: 1.25em;
+        font-weight: 700;
+        color: #fff;
+      }
+    }
+  }
+}
+
+.horizontalLineWhite {
+  width: 100%;
+  height: 2px;
+  background-color: #fff;
+}
+
+.horizontalLineBlack {
+  width: 100%;
+  height: 2px;
+  background-color: #000;
+}
+
+.eachMenuList {
+  display: flex;
+  flex-direction: column;
+
+  padding: 5px 20px;
+  gap: 5px;
+  width: 100%;
+  color: #fff;
+
+  & > a {
+    color: #fff;
+    text-decoration: none;
+  }
+
+  & > li:hover {
+    cursor: pointer;
+  }
+}
+
+.myPageContents {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0px 15px;
+  width: calc(80% - 30px);
+  height: 900px;
+  gap: 20px;
+}
+
+.myPageContentsTitle {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  gap: 5px;
+  margin-top: 20px;
+
+  & > p {
+    font-size: 24px;
+    font-weight: 700;
+  }
+}
+
+.recentTripBanner {
+  width: 100%;
+  height: 300px;
+  border-radius: 10px;
+  position: relative;
+  background-image: url("https://www.agoda.com/wp-content/uploads/2019/01/Things-to-do-in-Tokyo-Featured-photo.jpg");
+  background-size: cover;
+  background-repeat: no-repeat;
+}
+
+.reservationInfoContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+
+  width: 100%;
+}
+
+.reservationBanner {
+  width: 30%;
+  height: 440px;
+  border-radius: 10px;
+  background-color: #b9b7b7;
+}
+
+.reservation {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-bottom: 40px;
+}
+
+.reservationSubject {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  width: 100%;
+  margin-bottom: 15px;
+
+  & > p {
+    font-size: 1.25em;
+    font-weight: 700;
+    color: #000;
+  }
+
+  & > p > span {
+    font-size: 0.8em;
+    font-size: 300;
+
+    color: #b9b7b7;
+  }
+
+  & > p > span:hover {
+    cursor: pointer;
+  }
+}
+
+.infoListContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 15px;
+  width: 100%;
+}
+
+.eachReservationInfo {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  width: 99%;
+  height: 40px;
+  border-bottom: 1px solid #b9b7b7;
+}
+
+.airlineLeft {
+  display: flex;
+  flex-direction: column;
+}
+
+.airlineRight {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.airlineName {
+  font-size: 1em;
+  font-weight: 300;
+}
+
+.airlineId {
+  font-size: 1.25em;
+  font-weight: 700;
+}


### PR DESCRIPTION
# Summary
- 마이 페이지 메인화면을 퍼블리싱합니다.
- **13일 발표에서 보여줄 수 있는 단계로만 구현하였습니다.**

# Descriptions
## ```mypage/page.tsx```
- 마이페이지 입장시 보여질 메인 화면만을 퍼블리싱하였습니다.
- 마이페이지 메뉴바에서 접근할 수 있는 메뉴의 링크를 임시로 지정하였습니다.
  - 링크로 접속될 페이지들은 추후 구현하겠습니다. 
- **_!! 화면만 구성되었습니다. 기능은 추후 구현하겠습니다._**

### 마이페이지 구성
#### ```나의 여정```
- 최근 여정 관리
  - 이 항목이 마이페이지에 입장했을 경우 가장 먼저 렌더링되는 기본 항목입니다.
- 나의 예약 관리
- 나의 전체 여정 관리
- 나의 리뷰 관리

#### ```나의 친구```
- 친구 목록 / 관리

#### ```나의 프로필```
- 프로필 관리

#### ```개인정보 설정```
- 계정 설정
- 알림 설정

# Images
![image](https://github.com/DMU-Triple/Tripflutter_FE/assets/47844901/5438549b-6c59-4ef6-b448-f17b77d2bc89)





